### PR TITLE
Add OpenSeaMap layer to maps, enable it by default

### DIFF
--- a/src/components/maps/leafletMap.vue
+++ b/src/components/maps/leafletMap.vue
@@ -79,6 +79,12 @@
         maxZoom: 18,
       })
       //.addTo(this.map)
+      // OpenSeaMap
+      const openseamap = L.tileLayer('https://tiles.openseamap.org/seamark/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="http://www.openseamap.org">OpenSeaMap</a> contributors',
+        maxZoom: 18,
+      })
+      //.addTo(this.map)
       // Satellite
       const sat = L.tileLayer(
         'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
@@ -101,12 +107,15 @@
         Satellite: sat,
         NOAA: noaa,
       }
-      const overlays = {}
+      const overlays = {
+        OpenSeaMap: openseamap,
+      }
       if (this.controlLayer) {
         L.control.layers(baseMaps, overlays).addTo(this.map)
       }
       //baseMaps['OpenStreetMap'].addTo(this.map)
       baseMaps[this.mapType].addTo(this.map)
+      openseamap.addTo(this.map)
 
       const sailBoatIcon = function (feature, latlng) {
         return L.marker(latlng, {


### PR DESCRIPTION
As OpenStreetMap is used for maps, it makes sense to also show additional OpenSeaMap layer on the map.

This PR adds OpenSeaMap layer to all maps and enables it by default. 

Old default (OpenStreetMap):
<img width="825" alt="image" src="https://github.com/xbgmsharp/vuestic-postgsail/assets/46861689/406c2189-cd3a-4203-90ef-85be55f518db">

New default (OpenStreetMap + OpenSeaMap):
<img width="825" alt="image" src="https://github.com/xbgmsharp/vuestic-postgsail/assets/46861689/ab0645f7-26c1-4ba1-b87a-af3c4a6a853a">
