### PR TITLE
Map: show simple dot as marker on path

### DIFF
--- a/src/components/maps/leafletMap.vue
+++ b/src/components/maps/leafletMap.vue
@@ -117,6 +117,16 @@
       baseMaps[this.mapType].addTo(this.map)
       openseamap.addTo(this.map)
 
+      const simpleDot = function (feature, latlng) {
+        return L.circleMarker(latlng, {
+          radius: 2,
+          fillColor: '#00FFFF',
+          color: '#000',
+          weight: 1,
+          opacity: 1,
+          fillOpacity: 0.8,
+        })
+      }
       const sailBoatIcon = function (feature, latlng) {
         return L.marker(latlng, {
           icon: new L.Icon({
@@ -190,7 +200,7 @@
       }
 
       const layer = L.geoJSON(geojson, {
-        pointToLayer: sailBoatIcon,
+        pointToLayer: simpleDot,
         onEachFeature: popup,
       }).addTo(this.map)
       console.log('LeafletMap props.controlLayer', this.controlLayer, 'props.Zoom:', this.zoom)


### PR DESCRIPTION
Suggestion to use simple marker instead of sailboat which clutters the image

Before:
<img width="998" alt="image" src="https://github.com/xbgmsharp/vuestic-postgsail/assets/46861689/7160fdf5-0104-4ac4-9ef1-685d674c4888">

After:
<img width="821" alt="image" src="https://github.com/xbgmsharp/vuestic-postgsail/assets/46861689/27575283-c969-41e1-9b9e-551c969bd7f8">
