### PR TITLE
Timelapse: instruments (optional)

### DIFF
--- a/src/i18n/locales/br.json
+++ b/src/i18n/locales/br.json
@@ -461,6 +461,7 @@
     "boattype": "Show Boat As",
     "trackcolor": "Cor da trilha",
     "overlay": "Sobreposições de Moorage",
+    "instruments": "Show Instruments",
     "zoom": "Nível de Zoom",
     "anim": "Velocidade de Animação",
     "atraso": "Atraso inicial",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -467,6 +467,7 @@
     "boattype": "Show Boat As",
     "trackcolor": "Track Color",
     "overlay": "Show Moorage Overlays",
+    "instruments": "Show Instruments",
     "zoom": "Zoom Level",
     "anim": "Animation Speed",
     "delay": "Initial Delay",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -461,6 +461,7 @@
     "boattype": "Show Boat As",
     "trackcolor": "Color de pista",
     "overlay": "Superposiciones de amarre",
+    "instruments": "Show Instruments",
     "zoom": "Nivel de zoom",
     "anim": "Velocidad de animación",
     "retraso": "Retraso inicial",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -461,6 +461,7 @@
     "boattype": "Show Boat As",
     "trackcolor": "Couleur de la piste",
     "overlay": "Les superpositions d'amarrage",
+    "instruments": "Show Instruments",
     "zoom": "Niveau de zoom",
     "anim": "Vitesse d'animation",
     "delay": "Délai initial",

--- a/src/i18n/locales/gb.json
+++ b/src/i18n/locales/gb.json
@@ -473,6 +473,7 @@
     "boattype": "Show Boat As",
     "trackcolor": "Track Color",
     "overlay": "Show Moorage Overlay",
+    "instruments": "Show Instruments",
     "zoom": "Zoom Level",
     "anim": "Animation Speed",
     "delay": "Initial Delay",

--- a/src/pages/timelapse/Form.vue
+++ b/src/pages/timelapse/Form.vue
@@ -84,9 +84,13 @@
                 <tr>
                   <td>{{ $t('timelapse.overlay') }}</td>
                   <td>
-                    <div v-if="colors">
-                      <va-switch v-model="overlay" size="small" @click="handleOverlay" />
-                    </div>
+                    <va-switch v-model="overlay" size="small" @click="handleOverlay" />
+                  </td>
+                </tr>
+                <tr>
+                  <td>{{ $t('timelapse.instruments') }}</td>
+                  <td>
+                    <va-switch v-model="instruments" size="small" @click="handleInstruments" />
                   </td>
                 </tr>
                 <tr>
@@ -218,6 +222,7 @@
   const { logs } = storeToRefs(CacheStore)
   const choose_trips = ref(false)
   const overlay = ref(true)
+  const instruments = ref(false)
   const color = ref(0)
   const start_trip = ref(-1)
   const end_trip = ref(-1)
@@ -232,6 +237,7 @@
     zoom: 13,
     color: 'dodgerblue',
     moorage_overlay: overlay.value,
+    instruments: instruments.value,
   })
   const timelapse_link = computed(() => {
     console.log('formData', formData)
@@ -446,6 +452,10 @@
   const handleOverlay = async () => {
     console.log('handleOverlay', overlay.value)
     formData.moorage_overlay = !overlay.value
+  }
+  const handleInstruments = async () => {
+    console.log('handleInstruments', instruments.value)
+    formData.instruments = !instruments.value
   }
   const onsubmit = () => {
     console.log('onsubmit', formData)

--- a/src/pages/timelapse/Timelapse3.vue
+++ b/src/pages/timelapse/Timelapse3.vue
@@ -240,7 +240,7 @@
     const overlay = L.control({ position: 'topcenter' })
     overlay.onAdd = function () {
       const overlayView = L.DomUtil.create('div', 'overlay')
-      const topRow = L.DomUtil.create('div', 'top-row', overlayView)
+      const topRow = L.DomUtil.create('b', 'top-row', overlayView)
       L.DomUtil.create('span', 'trip', topRow)
       const bottomRow = L.DomUtil.create('div', 'bottom-row', overlayView)
       L.DomUtil.create('span', 'note', bottomRow)


### PR DESCRIPTION
## Description

Added **Show Instruments** option to Timelapse-Customize which allows to display instruments during replay:
<img width="938" alt="image" src="https://github.com/xbgmsharp/vuestic-postgsail/assets/46861689/2fb3b42f-eed6-4036-8870-64d106249caa">


I like and would even consider it as default option as we always have at least Speed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
