### PR TITLE
Logbook: add Engine hours to summary

### DIFF
--- a/src/pages/logs-book/DetailsMap.vue
+++ b/src/pages/logs-book/DetailsMap.vue
@@ -115,6 +115,20 @@
     tagsOptions = ref([])
 
   const item = computed(() => {
+    const extractEngineRunTimes = (metrics) => {
+      const engineRunTimes = []
+      for (const key in metrics) {
+        if (key.startsWith('propulsion.')) {
+          const parts = key.split('.')
+          if (parts.length === 3 && parts[2] === 'runTime') {
+            const engineName = parts[1]
+            const duration = durationFormatHours(metrics[key]) + ' ' + durationI18nHours(metrics[key])
+            engineRunTimes.push({ name: engineName, duration })
+          }
+        }
+      }
+      return engineRunTimes
+    }
     return apiData.row
       ? {
           id: apiData.row.id,
@@ -132,6 +146,7 @@
           max_wind_speed: speedFormatKnots(apiData.row.max_wind_speed),
           avg_wind_speed: speedFormatKnots(apiData.row?.extra?.avg_wind_speed || 0),
           extra: apiData.row?.extra?.metrics,
+          engineHours: extractEngineRunTimes(apiData.row?.extra?.metrics),
           seaState: apiData.row?.extra?.observations?.seaState || -1,
           cloudCoverage: apiData.row?.extra?.observations?.cloudCoverage || -1,
           visibility: apiData.row?.extra?.observations?.visibility || -1,

--- a/src/pages/logs-book/sidebars/Summary.vue
+++ b/src/pages/logs-book/sidebars/Summary.vue
@@ -167,7 +167,18 @@
     <va-icon class="flex-none" name="route" :size="32" />
     <div class="flex-grow ml-2 text-sm">{{ logbook.distance }} / {{ logbook.duration }}</div>
   </div>
-
+  <div v-if="logbook.engineHours && logbook.engineHours.length > 0">
+    <div class="text-xs uppercase">ENGINE</div>
+    <div class="flex items-center">
+      <va-icon class="flex-none" name="settings" :size="32" />
+      <ul>
+        <li v-for="(engine, index) in logbook.engineHours" :key="index" class="flex-grow ml-2 text-sm">
+          <div v-if="logbook.engineHours.length > 1">{{ engine.name }}:</div>
+          {{ engine.duration }}
+        </li>
+      </ul>
+    </div>
+  </div>
   <div class="text-xs uppercase mt-2">SPEED AVG / MAX</div>
   <div class="flex items-center">
     <va-icon class="flex-none" name="speed" :size="32" />

--- a/src/pages/logs-book/types.ts
+++ b/src/pages/logs-book/types.ts
@@ -20,6 +20,11 @@ export type Log = {
   tags: []
 }
 
+export type EngineRunTime = {
+  name: string
+  duration: string
+}
+
 export type Trip = {
   id: number
   name: string
@@ -31,6 +36,7 @@ export type Trip = {
   ended: string
   distance: number
   duration: string
+  engineHours: Array<EngineRunTime>
   notes: string
   geojson: JSONObject
   avg_speed: number


### PR DESCRIPTION
List engine hours for all engines on Log book Summary page

## Description

If propulsion.*.runTime property is provided, list engine hours on Summary page
<img width="350" alt="image" src="https://github.com/user-attachments/assets/771c416e-5b6b-4d10-828c-45a7c0bc4779">

Note: if there are multiple engines (e.g. catamaran) then we add name of engine to display. Needs to be tested with such boat.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
