### PR TITLE
Add Windy Station configuration to Profile

### DIFF
--- a/src/i18n/locales/br.json
+++ b/src/i18n/locales/br.json
@@ -329,6 +329,7 @@
     },
     "name": "Name",
     "website": "Website",
+    "windy_station": "Windy Station",
     "public_profile": "Public Profile",
     "public_name": "Name",
     "public_logs": "Log Details",
@@ -366,6 +367,7 @@
     "msg": {
       "website": "Website displayed alongside your stats, please enter the full URL starting with http:// or https://",
       "instagram_handle": "Instagram link displayed alongside your stats, please enter without a leading {'@'} sign",
+      "windy_station": "Windy station identifier as displayed in Windy URL after /station/pws- (e.g. d06efc48)",
       "public_profile": "When enabled, corresponding pages like stats, timelapse and others can be accessed by anyone without being required to login.",
       "public_logs": "When enabled, your individual log details will be publicly accessible at https://iot.openplotter.cloud/{0}/log/{'id'}",
       "public_stats": "When enabled, your statistics will be publicly accessible at https://iot.openplotter.cloud/{0}/stats",

--- a/src/i18n/locales/de.json
+++ b/src/i18n/locales/de.json
@@ -326,6 +326,7 @@
     },
     "name": "Name",
     "website": "Webseite",
+    "windy_station": "Windy Station",
     "public_profile": "Öffentliches Profil",
     "public_name": "Name",
     "public_logs": "Protokolldetails",
@@ -363,6 +364,7 @@
     "msg": {
       "website": "Website displayed alongside your stats, please enter the full URL starting with http:// or https://",
       "instagram_handle": "Instagram link displayed alongside your stats, please enter without a leading {'@'} sign",
+      "windy_station": "Windy station identifier as displayed in Windy URL after /station/pws- (e.g. d06efc48)",
       "public_profile": "When enabled, corresponding pages like stats, timelapse and others can be accessed by anyone without being required to login.",
       "public_logs": "When enabled, your individual log details will be publicly accessible at https://iot.openplotter.cloud/{0}/log/{'id'}",
       "public_stats": "When enabled, your statistics will be publicly accessible at https://iot.openplotter.cloud/{0}/stats",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -329,6 +329,7 @@
     },
     "name": "Name",
     "website": "Website",
+    "windy_station": "Windy Station",
     "public_profile": "Public Profile",
     "public_logs": "Log Details",
     "public_name": "Name",
@@ -366,6 +367,7 @@
     "msg": {
       "website": "Website displayed alongside your stats, please enter the full URL starting with http:// or https://",
       "instagram_handle": "Instagram link displayed alongside your stats, please enter without a leading {'@'} sign",
+      "windy_station": "Windy station identifier as displayed in Windy URL after /station/pws- (e.g. d06efc48)",
       "public_profile": "When enabled, corresponding pages like stats, timelapse and others can be accessed by anyone without being required to login.",
       "public_logs": "When enabled, your individual log details will be publicly accessible at https://iot.openplotter.cloud/{0}/log/{'id'}",
       "public_stats": "When enabled, your statistics will be publicly accessible at https://iot.openplotter.cloud/{0}/stats",

--- a/src/i18n/locales/fr.json
+++ b/src/i18n/locales/fr.json
@@ -322,6 +322,7 @@
     },
     "name": "Name",
     "website": "Website",
+    "windy_station": "Windy Station",
     "public_profile": "Public Profile",
     "public_name": "Name",
     "public_logs": "Log Details",
@@ -359,6 +360,7 @@
     "msg": {
       "website": "Website displayed alongside your stats, please enter the full URL starting with http:// or https://",
       "instagram_handle": "Instagram link displayed alongside your stats, please enter without a leading {'@'} sign",
+      "windy_station": "Windy station identifier as displayed in Windy URL after /station/pws- (e.g. d06efc48)",
       "public_profile": "When enabled, corresponding pages like stats, timelapse and others can be accessed by anyone without being required to login.",
       "public_logs": "When enabled, your individual log details will be publicly accessible at https://iot.openplotter.cloud/{0}/log/{'id'}",
       "public_stats": "When enabled, your statistics will be publicly accessible at https://iot.openplotter.cloud/{0}/stats",

--- a/src/i18n/locales/gb.json
+++ b/src/i18n/locales/gb.json
@@ -332,6 +332,7 @@
     },
     "name": "Name",
     "website": "Website",
+    "windy_station": "Windy Station",
     "public_profile": "Public Profile",
     "public_name": "Name",
     "public_logs": "Log Details",
@@ -369,6 +370,7 @@
     "msg": {
       "website": "Website displayed alongside your stats, please enter the full URL starting with http:// or https://",
       "instagram_handle": "Instagram link displayed alongside your stats, please enter without a leading {'@'} sign",
+      "windy_station": "Windy station identifier as displayed in Windy URL after /station/pws- (e.g. d06efc48)",
       "public_profile": "When enabled, corresponding pages like stats, timelapse and others can be accessed by anyone without being required to login.",
       "public_logs": "When enabled, your individual log details will be publicly accessible at https://iot.openplotter.cloud/{0}{1}/log/{0}",
       "public_stats": "When enabled, your statistics will be publicly accessible at https://iot.openplotter.cloud/{0}/stats",

--- a/src/pages/profile/OverviewTab.vue
+++ b/src/pages/profile/OverviewTab.vue
@@ -61,6 +61,21 @@
           </tr>
           <tr>
             <td>
+              <va-popover class="mr-2 mb-2" icon="info" :message="$t('profile.msg.windy_station')">
+                {{ t('profile.windy_station') }}
+              </va-popover>
+            </td>
+            <td class="centerContainer">
+              <VaInput
+                v-model="localpref.windy"
+                outline
+                placeholder="(e.g. d06efc48)"
+                @change="UpdatePref('windy', settings.preferences.windy)"
+              />
+            </td>
+          </tr>
+          <tr>
+            <td>
               <va-popover
                 class="mr-2 mb-2"
                 icon="info"
@@ -234,7 +249,7 @@
             <tr class="sub-setting">
               <td>
                 <va-popover class="mr-2 mb-2" icon="info" :message="$t('profile.msg.public_windy')">
-                  Windy Station
+                  {{ t('profile.windy_station') }}
                 </va-popover>
               </td>
               <td class="">


### PR DESCRIPTION
Allow configuration of Windy station that is created with signalk-windy-plugin

## Description

I use [signalk-windy-plugin](https://github.com/Saillogger/signalk-windy-plugin) to create Windy Station on my boat.
This allows configuring Windy station (PWS) identifier in Profile.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
