### PR TITLE
Explore map: dark mode, mobile fixes

### DIFF
--- a/src/components/maps/leafletMap.vue
+++ b/src/components/maps/leafletMap.vue
@@ -489,6 +489,7 @@
   }
   .sidepanel {
     z-index: 10;
+    width: 320px;
   }
   .sidebar-tab-link.active,
   .sidebar-tab-link:hover {

--- a/src/components/maps/leafletMap.vue
+++ b/src/components/maps/leafletMap.vue
@@ -474,6 +474,9 @@
     a {
       cursor: pointer;
     }
+    h4 {
+      font-weight: bold;
+    }
   }
   #saveNoteButton {
     width: 50%;

--- a/src/components/maps/leafletMap.vue
+++ b/src/components/maps/leafletMap.vue
@@ -490,6 +490,7 @@
   .sidepanel {
     z-index: 10;
     width: 320px;
+    height: 100%;
   }
   .sidebar-tab-link.active,
   .sidebar-tab-link:hover {

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -10,6 +10,7 @@
   import PostgSail from '../../services/api-client'
   import { dateFormatUTC, durationFormatHours, fromNow, nowUTC } from '../../utils/dateFormatter.js'
   import { distanceFormatMiles, distanceFormat, depthFormatI18n } from '../../utils/distanceFormatter.js'
+  import { angleFormat } from '../../utils/angleFormatter.js'
   import { speedFormatKnots } from '../../utils/speedFormatter.js'
   import { stayed_at_options } from '../../utils/PostgSail.ts'
   import { kelvinToHuman } from '../../utils/temperatureFormatter.js'
@@ -766,9 +767,9 @@
                       <div class="flex items-center space-x-4" v-if="items.wind.speed">
                         <!-- Left Column -->
                         <div class="flex flex-col text-sm space-y-1 min-w-[100px]">
-                          <div>Depth: {{ items.water.depth }}</div>
-                          <div>Wind Speed: {{ items.wind.speed }} Kt</div>
-                          <div>Wind Direction: {{ items.wind.direction }}°</div>
+                          <div>Wind Speed: {{ speedFormatKnots(items.wind.speed) }}</div>
+                          <div>Wind Direction: {{ angleFormat(items.wind.direction) }}</div>
+                          <div>Depth: {{ depthFormatI18n(items.water.depth) }}</div>
                         </div>
 
                         <!-- Right Column (Wind Compass) -->
@@ -777,13 +778,6 @@
                           :title="`Wind: ${items.wind.speed} Kt, ${items.wind.direction} deg`"
                           v-if="items.wind.speed && items.wind.direction"
                         >
-                          <!-- Value on top (optional, you might remove this if redundant) -->
-                          <div
-                            class="absolute -top-7 left-1/2 transform -translate-x-1/2 text-sm font-medium text-center px-1 max-w-[6rem] truncate"
-                          >
-                            {{ items.wind.speed }} Kt – {{ items.wind.direction }}°
-                          </div>
-
                           <!-- Circular wind speed ring -->
                           <svg class="speed-circle" viewBox="0 0 100 100">
                             <circle class="bg" cx="50" cy="50" r="45" />

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -728,7 +728,7 @@
                           class="va-link"
                           @mouseenter="onLogMouseEnter(log.properties.logIndex)"
                           @click="onLogClickNavigate(log.properties.centercoords, log.properties.logIndex)"
-                          >{{ log.properties.name }} • {{ durationFormatHours(log.properties.duration) }}H •
+                          >{{ log.properties.name }} • {{ durationFormatHours(log.properties.duration) }} h •
                           {{ distanceFormatMiles(log.properties.distance) }}
                         </a>
                       </li>

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -942,6 +942,9 @@
     a {
       cursor: pointer;
     }
+    h4 {
+      font-weight: bold;
+    }
   }
   .line-item:hover {
     background-color: yellow;

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -45,8 +45,6 @@
   const api_geojson = ref({})
   const map = ref(null)
   const currentZoom = ref(7)
-  const tabs = ['Logs', 'Moorages']
-  const sidepanelLeft = ref(null)
   const mooragesLayers = ref([])
   const mooragesMakers = ref([])
   const logsLayers = ref([])
@@ -127,18 +125,20 @@
     })
 
     // Create a side panel on the left
-    sidepanelLeft.value = L.control
-      .sidepanel('sidepanelLeft', {
+    L.control
+      .sidepanel('sidepanel', {
+        panelPosition: 'left',
+        hasTabs: true,
         tabsPosition: 'top',
-        startTab: 'tab-1',
         pushControls: true,
         darkMode: currentTheme === 'dark',
+        startTab: 'tab-1',
       })
       .addTo(map.value)
 
     map.value.whenReady(function () {
       addResetViewControl()
-      const sidepanel = document.getElementById('sidepanelLeft')
+      const sidepanel = document.getElementById('sidepanel')
 
       // Watch class changes
       const observer = new MutationObserver((mutations) => {
@@ -690,8 +690,7 @@
   <va-inner-loading v-if="logsList.length > 0 || isBusy" :loading="isBusy">
     <div class="explore-maps leaflet-map__full">
       <div>
-        <!-- Side Panel left -->
-        <div id="sidepanelLeft" class="sidepanel" aria-label="side panel" aria-hidden="false">
+        <div id="sidepanel" class="sidepanel" aria-label="side panel" aria-hidden="false">
           <div class="sidepanel-inner-wrapper">
             <nav class="sidepanel-tabs-wrapper" aria-label="sidepanel tab navigation">
               <ul class="sidepanel-tabs">
@@ -875,8 +874,7 @@
             <button class="sidepanel-toggle-button" type="button" aria-label="toggle side panel"></button>
           </div>
         </div>
-
-        <div id="explore-map" class=""></div>
+        <div id="explore-map" class="leaflet-map"></div>
       </div>
     </div>
     <template v-if="logsSlider.length > 1">

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -26,6 +26,8 @@
   const GlobalStore = useGlobalStore()
   const { isSidebarMinimized } = storeToRefs(GlobalStore)
 
+  const { currentTheme } = useGlobalStore()
+
   import { useI18n } from 'vue-i18n'
   const { t } = useI18n()
 
@@ -129,6 +131,8 @@
       .sidepanel('sidepanelLeft', {
         tabsPosition: 'top',
         startTab: 'tab-1',
+        pushControls: true,
+        darkMode: currentTheme === 'dark',
       })
       .addTo(map.value)
 
@@ -680,242 +684,242 @@
 </script>
 
 <template>
-  <VaCard
-    ><VaCardContent>
-      <template v-if="apiError">
-        <va-alert color="danger" outline class="mb-4">{{ $t('api.error') }}: {{ apiError }}</va-alert>
-      </template>
-      <va-inner-loading v-if="logsList.length > 0 || isBusy" :loading="isBusy">
-        <div class="explore-maps leaflet-map__full">
-          <template v-if="logsSlider.length > 1">
-            <va-slider
-              v-if="logsSlider.length > 1"
-              v-model="selectedRange"
-              :range="true"
-              :min="0"
-              :max="logsSlider.length - 1"
-              :step="1"
-              show-markers
-              :tooltip="true"
-              :tooltip-label="tooltipLabel"
-            />
-            {{ formattedDateRange }}
-          </template>
-          <div>
-            <!-- Side Panel left -->
-            <div id="sidepanelLeft" class="sidepanel" aria-label="side panel" aria-hidden="false">
-              <div class="sidepanel-inner-wrapper">
-                <nav class="sidepanel-tabs-wrapper" aria-label="sidepanel tab navigation">
-                  <ul class="sidepanel-tabs">
-                    <li class="sidepanel-tab">
-                      <a href="#" class="sidebar-tab-link" role="tab" data-tab-link="tab-1" @click="onLogsTabClick">
-                        <va-icon name="menu-logs" />
-                      </a>
-                    </li>
-                    <li class="sidepanel-tab">
-                      <a href="#" class="sidebar-tab-link" role="tab" data-tab-link="tab-2" @click="onMooragesTabClick">
-                        <va-icon name="menu-moorages" />
-                      </a>
-                    </li>
-                    <li class="sidepanel-tab">
-                      <a
-                        href="#"
-                        class="sidebar-tab-link"
-                        role="tab"
-                        data-tab-link="tab-3"
-                        @click="onMonitoringTabClick"
+  <template v-if="apiError">
+    <va-alert color="danger" outline class="mb-4">{{ $t('api.error') }}: {{ apiError }}</va-alert>
+  </template>
+  <va-inner-loading v-if="logsList.length > 0 || isBusy" :loading="isBusy">
+    <div class="explore-maps leaflet-map__full">
+      <div>
+        <!-- Side Panel left -->
+        <div id="sidepanelLeft" class="sidepanel" aria-label="side panel" aria-hidden="false">
+          <div class="sidepanel-inner-wrapper">
+            <nav class="sidepanel-tabs-wrapper" aria-label="sidepanel tab navigation">
+              <ul class="sidepanel-tabs">
+                <li class="sidepanel-tab">
+                  <a href="#" class="sidebar-tab-link" role="tab" data-tab-link="tab-1" @click="onLogsTabClick">
+                    <va-icon name="timeline" />
+                  </a>
+                </li>
+                <li class="sidepanel-tab">
+                  <a href="#" class="sidebar-tab-link" role="tab" data-tab-link="tab-2" @click="onMooragesTabClick">
+                    <va-icon name="anchor" />
+                  </a>
+                </li>
+                <li class="sidepanel-tab">
+                  <a href="#" class="sidebar-tab-link" role="tab" data-tab-link="tab-3" @click="onMonitoringTabClick">
+                    <va-icon name="my_location" />
+                  </a>
+                </li>
+              </ul>
+            </nav>
+            <div class="sidepanel-content-wrapper">
+              <div class="sidepanel-content">
+                <div id="logs-list" class="sidepanel-tab-content" data-tab-content="tab-1">
+                  <div>
+                    <ol>
+                      <li
+                        class="line-item"
+                        id="lists"
+                        v-if="logsList.length > 0"
+                        v-for="(log, index) in logsList"
+                        :key="index"
                       >
-                        <va-icon name="menu-monitoring" />
-                      </a>
-                    </li>
-                  </ul>
-                </nav>
-                <div class="sidepanel-content-wrapper">
-                  <div class="sidepanel-content">
-                    <div id="logs-list" class="sidepanel-tab-content" data-tab-content="tab-1">
-                      <div>
-                        <ol>
-                          <li
-                            class="line-item"
-                            id="lists"
-                            v-if="logsList.length > 0"
-                            v-for="(log, index) in logsList"
-                            :key="index"
+                        {{ index + 1 }}.
+                        <a
+                          class="va-link"
+                          @mouseenter="onLogMouseEnter(log.properties.logIndex)"
+                          @click="onLogClickNavigate(log.properties.centercoords, log.properties.logIndex)"
+                          >{{ log.properties.name }} • {{ durationFormatHours(log.properties.duration) }}H •
+                          {{ distanceFormatMiles(log.properties.distance) }}
+                        </a>
+                      </li>
+                    </ol>
+                  </div>
+                </div>
+                <div id="moorages-list" class="sidepanel-tab-content" data-tab-content="tab-2">
+                  <div>
+                    <ol>
+                      <li
+                        class="line-item"
+                        id="lists"
+                        v-if="mooragesList.length > 0"
+                        v-for="(moorage, index) in mooragesList"
+                        :key="index"
+                      >
+                        {{ index + 1 }}.
+                        <a
+                          class="va-link"
+                          @mouseenter="onMoorageMouseEnter(moorage.properties.moorageIndex)"
+                          @mouseleave="stopBouncingMarker(moorage.properties.moorageIndex)"
+                          @click="onMoorageClickNavigate(moorage.geometry.coordinates, moorage.properties.moorageIndex)"
+                          >{{ moorage.properties.name }}</a
+                        >
+                      </li>
+                    </ol>
+                  </div>
+                </div>
+                <div id="real-time" class="sidepanel-tab-content" data-tab-content="tab-3">
+                  <div class="w-full" v-if="items">
+                    <h2 class="">{{ items.updated }} <span class="dot"></span></h2>
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Wind & Depth</h3>
+                    <div class="w-full flex justify-center items-center">
+                      <div class="flex items-center space-x-4" v-if="items.wind.speed">
+                        <!-- Left Column -->
+                        <div class="flex flex-col text-sm space-y-1 min-w-[100px]">
+                          <div>Depth: {{ items.water.depth }}</div>
+                          <div>Wind Speed: {{ items.wind.speed }} Kt</div>
+                          <div>Wind Direction: {{ items.wind.direction }}°</div>
+                        </div>
+
+                        <!-- Right Column (Wind Compass) -->
+                        <div
+                          class="wind-compass group relative"
+                          :title="`Wind: ${items.wind.speed} Kt, ${items.wind.direction} deg`"
+                          v-if="items.wind.speed && items.wind.direction"
+                        >
+                          <!-- Value on top (optional, you might remove this if redundant) -->
+                          <div
+                            class="absolute -top-7 left-1/2 transform -translate-x-1/2 text-sm font-medium text-center px-1 max-w-[6rem] truncate"
                           >
-                            {{ index + 1 }}.
-                            <a
-                              class="va-link"
-                              @mouseenter="onLogMouseEnter(log.properties.logIndex)"
-                              @click="onLogClickNavigate(log.properties.centercoords, log.properties.logIndex)"
-                              >{{ log.properties.name }} • {{ durationFormatHours(log.properties.duration) }}H •
-                              {{ distanceFormatMiles(log.properties.distance) }}
-                            </a>
-                          </li>
-                        </ol>
-                      </div>
-                    </div>
-                    <div id="moorages-list" class="sidepanel-tab-content" data-tab-content="tab-2">
-                      <div>
-                        <ol>
-                          <li
-                            class="line-item"
-                            id="lists"
-                            v-if="mooragesList.length > 0"
-                            v-for="(moorage, index) in mooragesList"
-                            :key="index"
-                          >
-                            {{ index + 1 }}.
-                            <a
-                              class="va-link"
-                              @mouseenter="onMoorageMouseEnter(moorage.properties.moorageIndex)"
-                              @mouseleave="stopBouncingMarker(moorage.properties.moorageIndex)"
-                              @click="
-                                onMoorageClickNavigate(moorage.geometry.coordinates, moorage.properties.moorageIndex)
-                              "
-                              >{{ moorage.properties.name }}</a
-                            >
-                          </li>
-                        </ol>
-                      </div>
-                    </div>
-                    <div id="real-time" class="sidepanel-tab-content" data-tab-content="tab-3">
-                      <div class="w-full" v-if="items">
-                        <h2 class="">{{ items.updated }} <span class="dot"></span></h2>
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Wind & Depth</h3>
-                        <div class="w-full flex justify-center items-center">
-                          <div class="flex items-center space-x-4" v-if="items.wind.speed">
-                            <!-- Left Column -->
-                            <div class="flex flex-col text-sm space-y-1 min-w-[100px]">
-                              <div>Depth: {{ items.water.depth }}</div>
-                              <div>Wind Speed: {{ items.wind.speed }} Kt</div>
-                              <div>Wind Direction: {{ items.wind.direction }}°</div>
-                            </div>
-
-                            <!-- Right Column (Wind Compass) -->
-                            <div
-                              class="wind-compass group relative"
-                              :title="`Wind: ${items.wind.speed} Kt, ${items.wind.direction} deg`"
-                              v-if="items.wind.speed && items.wind.direction"
-                            >
-                              <!-- Value on top (optional, you might remove this if redundant) -->
-                              <div
-                                class="absolute -top-7 left-1/2 transform -translate-x-1/2 text-sm font-medium text-center px-1 max-w-[6rem] truncate"
-                              >
-                                {{ items.wind.speed }} Kt – {{ items.wind.direction }}°
-                              </div>
-
-                              <!-- Circular wind speed ring -->
-                              <svg class="speed-circle" viewBox="0 0 100 100">
-                                <circle class="bg" cx="50" cy="50" r="45" />
-                                <circle
-                                  class="progress"
-                                  :stroke="getSpeedColor(items.wind.speed)"
-                                  cx="50"
-                                  cy="50"
-                                  r="45"
-                                  :stroke-dasharray="dashArray"
-                                  stroke-dashoffset="0"
-                                />
-                              </svg>
-
-                              <!-- Rotating Arrow -->
-                              <svg
-                                class="arrow-svg"
-                                :style="{ transform: `rotate(${items.wind.direction}deg)` }"
-                                viewBox="0 0 36 36"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  x="3"
-                                  y="3"
-                                  width="25"
-                                  height="25"
-                                  transform="rotate(-249.5,15.5,15.5)"
-                                  fill="#145da0"
-                                  d="M26.675824776131577 2.519999999999989L2.500000600307402 13.822982731554148 2.500000600307402 14.764897959183662 10.46703356734037 18.728791208791197ZM11.291209391516192 19.55296703296702L15.25510264112373 27.51999999999999 16.197017868753242 27.51999999999999 27.500000600307402 3.3441758241758133Z"
-                                />
-                              </svg>
-                            </div>
+                            {{ items.wind.speed }} Kt – {{ items.wind.direction }}°
                           </div>
-                        </div>
 
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Temperature</h3>
-                        <div class="w-full h-24" v-if="items.temperature.inside">
-                          <echartsProgress
-                            :series="[items.temperature.inside]"
-                            title="Inside"
-                            :alarm="items.alarm.low_indoor_temperature_threshold"
-                          />
-                        </div>
-                        <div class="w-full h-24" v-if="items.temperature.outside">
-                          <echartsProgress
-                            :series="[items.temperature.outside]"
-                            title="Outside"
-                            :alarm="items.alarm.low_outdoor_temperature_threshold"
-                          />
-                        </div>
-                        <div class="w-full h-24" v-if="items.water.temperature">
-                          <echartsProgress
-                            :series="[items.water.temperature]"
-                            title="Water"
-                            :alarm="items.alarm.low_water_temperature_threshold"
-                          />
-                        </div>
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Humidity</h3>
-                        <div class="w-full h-24" v-if="items.humidity.inside">
-                          <echartsProgress :series="[items.humidity.inside]" title="Inside" :max="100" unit="%" />
-                        </div>
-                        <div class="w-full h-24" v-if="items.humidity.outside">
-                          <echartsProgress :series="[items.humidity.inside]" title="Outside" :max="100" unit="%" />
-                        </div>
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Battery</h3>
-                        <div class="w-full h-28" v-if="items.battery.charge">
-                          <echartsGauge :series="[parseInt(items.battery.charge), items.battery.voltage]" />
-                        </div>
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Solar</h3>
-                        <div class="w-full h-28" v-if="items.solar.power">
-                          <echartsGauge :series="[items.solar.power, items.solar.voltage]" unit="W" />
-                        </div>
-                        <hr class="cool-hr" />
-                        <h3 class="font-semibold">Tank</h3>
-                        <div class="w-full h-28" v-if="items.tank.level">
-                          <echartsGauge :series="[items.tank.level, items.tank.level]" unit="%" />
+                          <!-- Circular wind speed ring -->
+                          <svg class="speed-circle" viewBox="0 0 100 100">
+                            <circle class="bg" cx="50" cy="50" r="45" />
+                            <circle
+                              class="progress"
+                              :stroke="getSpeedColor(items.wind.speed)"
+                              cx="50"
+                              cy="50"
+                              r="45"
+                              :stroke-dasharray="dashArray"
+                              stroke-dashoffset="0"
+                            />
+                          </svg>
+
+                          <!-- Rotating Arrow -->
+                          <svg
+                            class="arrow-svg"
+                            :style="{ transform: `rotate(${items.wind.direction}deg)` }"
+                            viewBox="0 0 36 36"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              x="3"
+                              y="3"
+                              width="25"
+                              height="25"
+                              transform="rotate(-249.5,15.5,15.5)"
+                              fill="#145da0"
+                              d="M26.675824776131577 2.519999999999989L2.500000600307402 13.822982731554148 2.500000600307402 14.764897959183662 10.46703356734037 18.728791208791197ZM11.291209391516192 19.55296703296702L15.25510264112373 27.51999999999999 16.197017868753242 27.51999999999999 27.500000600307402 3.3441758241758133Z"
+                            />
+                          </svg>
                         </div>
                       </div>
+                    </div>
+
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Temperature</h3>
+                    <div class="w-full h-24" v-if="items.temperature.inside">
+                      <echartsProgress
+                        :series="[items.temperature.inside]"
+                        title="Inside"
+                        :alarm="items.alarm.low_indoor_temperature_threshold"
+                      />
+                    </div>
+                    <div class="w-full h-24" v-if="items.temperature.outside">
+                      <echartsProgress
+                        :series="[items.temperature.outside]"
+                        title="Outside"
+                        :alarm="items.alarm.low_outdoor_temperature_threshold"
+                      />
+                    </div>
+                    <div class="w-full h-24" v-if="items.water.temperature">
+                      <echartsProgress
+                        :series="[items.water.temperature]"
+                        title="Water"
+                        :alarm="items.alarm.low_water_temperature_threshold"
+                      />
+                    </div>
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Humidity</h3>
+                    <div class="w-full h-24" v-if="items.humidity.inside">
+                      <echartsProgress :series="[items.humidity.inside]" title="Inside" :max="100" unit="%" />
+                    </div>
+                    <div class="w-full h-24" v-if="items.humidity.outside">
+                      <echartsProgress :series="[items.humidity.inside]" title="Outside" :max="100" unit="%" />
+                    </div>
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Battery</h3>
+                    <div class="w-full h-28" v-if="items.battery.charge">
+                      <echartsGauge :series="[parseInt(items.battery.charge), items.battery.voltage]" />
+                    </div>
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Solar</h3>
+                    <div class="w-full h-28" v-if="items.solar.power">
+                      <echartsGauge :series="[items.solar.power, items.solar.voltage]" unit="W" />
+                    </div>
+                    <hr class="cool-hr" />
+                    <h3 class="font-semibold">Tank</h3>
+                    <div class="w-full h-28" v-if="items.tank.level">
+                      <echartsGauge :series="[items.tank.level, items.tank.level]" unit="%" />
                     </div>
                   </div>
                 </div>
               </div>
-              <div class="sidepanel-toggle-container">
-                <button class="sidepanel-toggle-button" type="button" aria-label="toggle side panel"></button>
-              </div>
             </div>
-
-            <div id="explore-map" class=""></div>
+          </div>
+          <div class="sidepanel-toggle-container">
+            <button class="sidepanel-toggle-button" type="button" aria-label="toggle side panel"></button>
           </div>
         </div>
-      </va-inner-loading> </VaCardContent
-  ></VaCard>
+
+        <div id="explore-map" class=""></div>
+      </div>
+    </div>
+    <template v-if="logsSlider.length > 1">
+      <div class="date-slider">
+        <va-slider
+          v-if="logsSlider.length > 1"
+          v-model="selectedRange"
+          :range="true"
+          :min="0"
+          :max="logsSlider.length - 1"
+          :step="1"
+          show-markers
+          :tooltip="true"
+          :tooltip-label="tooltipLabel"
+        />
+        {{ formattedDateRange }}
+      </div>
+    </template>
+  </va-inner-loading>
 </template>
 
-<style>
+<style lang="scss">
   #explore-map {
+    z-index: 0;
     width: 100%;
-    height: calc(91vh - 5rem);
+    height: calc(91vh - 4rem);
   }
   .sidepanel {
-    width: 350px;
-    height: calc(91vh - 5rem);
+    z-index: 10;
+    width: 320px;
+    height: calc(91vh - 4rem);
     .sidepanel-content {
-      width: 350px;
-      height: calc(91vh - 5rem);
+      width: 320px;
+      height: calc(91vh - 4rem);
     }
-    z-index: 999999 !important;
+  }
+  .sidebar-tab-link.active,
+  .sidebar-tab-link:hover {
+    color: var(--va-primary) !important;
+    border-bottom-color: var(--va-primary) !important;
+  }
+  .date-slider {
+    padding: 0.5rem 2rem 0.5rem 2rem;
   }
   .mpopup {
     td:nth-child(1) {

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -309,14 +309,14 @@
     let text = `<div class='mpopup'>
                           <h4><a href="/log/${feature.properties.id}">${feature.properties.name}</a></h4><br/>
                           <table class='data'><tbody>
-                          <tr><td>Start Time</td><td>${starttime}</td></tr>
-                          <tr><td>End Time</td><td>${endtime}</td></tr>
-                          <tr><td>Distance</td><td>${distance}</td></tr>
-                          <tr><td>Duration</td><td>${duration} hours</td></tr>
-                          <tr><td>Speed</td><td>avg ${avg_speed} / max ${max_speed}</td></tr>
-                          <tr><td>Wind</td><td>avg ${avg_tws} / max ${max_tws}</td></tr>
-                          <tr><td>Depth</td><td>avg ${avg_depth} / max ${max_depth}</td></tr>
-                          <tr><td>Notes</td><td>${notes}</td></tr>
+                          <tr><th>Start Time</th><td>${starttime}</td></tr>
+                          <tr><th>End Time</th><td>${endtime}</td></tr>
+                          <tr><th>Distance</th><td>${distance}</td></tr>
+                          <tr><th>Duration</th><td>${duration} hours</td></tr>
+                          <tr><th>Speed</th><td>avg ${avg_speed} / max ${max_speed}</td></tr>
+                          <tr><th>Wind</th><td>avg ${avg_tws} / max ${max_tws}</td></tr>
+                          <tr><th>Depth</th><td>avg ${avg_depth} / max ${max_depth}</td></tr>
+                          <tr><th>Notes</th><td>${notes}</td></tr>
                           </tbody></table></br>
                           <a href="/timelapse/${feature.properties.id}">Replay</a>
                         </div>`
@@ -920,11 +920,12 @@
     padding: 0.5rem 2rem 0.5rem 2rem;
   }
   .mpopup {
-    td:nth-child(1) {
+    th {
       text-align: right;
       padding-right: 5px;
+      font-weight: normal;
     }
-    td:nth-child(2) {
+    td {
       font-weight: bold;
     }
     a {

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -124,7 +124,6 @@
       })
     })
 
-    // Create a side panel on the left
     L.control
       .sidepanel('sidepanel', {
         panelPosition: 'left',
@@ -897,18 +896,30 @@
 </template>
 
 <style lang="scss">
-  #explore-map {
+  $map-height: calc(91vh - 3.5rem);
+  $map-height-mobile: calc(80vh - 3rem);
+
+  .leaflet-map {
     z-index: 0;
     width: 100%;
-    height: calc(91vh - 4rem);
+    height: $map-height;
+    @media (max-width: 768px) {
+      height: $map-height-mobile;
+    }
   }
   .sidepanel {
     z-index: 10;
     width: 320px;
-    height: calc(91vh - 4rem);
+    height: $map-height;
+    @media (max-width: 768px) {
+      height: $map-height-mobile;
+    }
     .sidepanel-content {
       width: 320px;
-      height: calc(91vh - 4rem);
+      height: $map-height;
+      @media (max-width: 768px) {
+        height: $map-height-mobile;
+      }
     }
   }
   .sidebar-tab-link.active,

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -928,6 +928,7 @@
     border-bottom-color: var(--va-primary) !important;
   }
   .date-slider {
+    color: var(--va-primary) !important;
     padding: 0.5rem 2rem 0.5rem 2rem;
   }
   .mpopup {

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -874,7 +874,6 @@
     <template v-if="logsSlider.length > 1">
       <div class="date-slider">
         <va-slider
-          v-if="logsSlider.length > 1"
           v-model="selectedRange"
           :range="true"
           :min="0"

--- a/src/components/maps/leafletMapExplorer.vue
+++ b/src/components/maps/leafletMapExplorer.vue
@@ -174,6 +174,7 @@
     if (!api_geojson.value?.features) return []
     return api_geojson.value.features
       .filter((feature) => feature.geometry.type === 'Point')
+      .sort((a, b) => b.geometry.coordinates[1] - a.geometry.coordinates[1]) // north to south
       .map((feature, index) => {
         feature.properties['moorageIndex'] = index // keep original index
         return feature

--- a/src/components/maps/leafletMapMoorages.vue
+++ b/src/components/maps/leafletMapMoorages.vue
@@ -77,7 +77,9 @@
   import { useI18n } from 'vue-i18n'
   const { t } = useI18n()
 
+  import { useGlobalStore } from '../../stores/global-store'
   import { useVesselStore } from '../../stores/vessel-store'
+  const { currentTheme } = useGlobalStore()
   const { vesselName, vesselType } = useVesselStore()
 
   const isBusy = ref(false),
@@ -263,7 +265,7 @@
           hasTabs: true,
           tabsPosition: 'top',
           pushControls: true,
-          //darkMode: currentTheme === 'dark',
+          darkMode: currentTheme === 'dark',
           startTab: 'tab-moorages1',
         })
         .addTo(map.value)

--- a/src/components/maps/leafletMapMoorages.vue
+++ b/src/components/maps/leafletMapMoorages.vue
@@ -435,8 +435,10 @@
   }
   .sidepanel {
     width: 320px;
+    height: 100%;
     .sidepanel-content {
       width: 320px;
+      height: 100%;
     }
   }
   .sidebar-tab-link.active,

--- a/src/components/maps/leafletMapMoorages.vue
+++ b/src/components/maps/leafletMapMoorages.vue
@@ -433,6 +433,12 @@
       font-weight: bold;
     }
   }
+  .sidepanel {
+    width: 320px;
+    .sidepanel-content {
+      width: 320px;
+    }
+  }
   .sidebar-tab-link.active,
   .sidebar-tab-link:hover {
     color: var(--va-primary) !important;

--- a/src/pages/logs-book/DetailsMap.vue
+++ b/src/pages/logs-book/DetailsMap.vue
@@ -474,8 +474,10 @@
   }
   .sidepanel {
     width: 320px;
+    height: 100%;
     .sidepanel-content {
       width: 320px;
+      height: 100%;
     }
   }
   .va-input-wrapper__field.va-input-wrapper__text.va-input__content__input {

--- a/src/pages/logs-book/DetailsMap.vue
+++ b/src/pages/logs-book/DetailsMap.vue
@@ -473,9 +473,9 @@
     height: calc(100vh - 4.5rem);
   }
   .sidepanel {
-    width: 350px;
+    width: 320px;
     .sidepanel-content {
-      width: 350px;
+      width: 320px;
     }
   }
   .va-input-wrapper__field.va-input-wrapper__text.va-input__content__input {

--- a/src/pages/monitoring/Monitoring.vue
+++ b/src/pages/monitoring/Monitoring.vue
@@ -244,8 +244,10 @@
   }
   .sidepanel {
     width: 240px;
+    height: 100%;
     .sidepanel-content {
       width: 240px;
+      height: 100%;
     }
   }
 </style>


### PR DESCRIPTION
## Description

Various improvements in new Explore Map
- sidebar supports dark mode
- move date slider to bootom
- use material icons for tabs
- fix popup formatting
- reduce sidebar do 320px (usable also on phones)

<img width="1118" alt="image" src="https://github.com/user-attachments/assets/78172fdb-d538-40a6-a2b9-9572a41c59e1" />

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Improvement/refactoring (non-breaking change that doesn't add any feature but make things better)
