### PR TITLE
fix(router): allow logout when user has no vessel

### DIFF
--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -451,7 +451,7 @@ router.beforeEach(async (to, from, next) => {
       return
     }
     // Enforce vessel creation
-    if (to.name != 'boat-new' && isLoggedIn && validEmail && !hasVessel) {
+    if (to.name != 'boat-new' && to.name != 'logout' && isLoggedIn && validEmail && !hasVessel) {
       next({ name: 'boat-new' })
       return
     }


### PR DESCRIPTION
## Summary

Users logged in without a registered vessel (`has_vessel=false`) could not sign out: navigating to `/logout` was intercepted by the vessel-creation guard and redirected to `boat/new` before `Logout.vue` could clear the session.

This affects service accounts and admins who register vessels via API but never complete the in-UI “Add boat” flow.

## Fix

Exempt route name `logout` from the `!hasVessel` redirect (same pattern as the existing `boat-new` exemption).

Replaces #164 (that PR targeted unrelated `main`; this one is a single commit on `live`).

## Test plan

- [ ] Sign up / log in as a user with `has_vessel=false` and validated email
- [ ] Open `/logout` (or Profile → Logout)
- [ ] Confirm redirect to login and session cleared (not stuck on Add boat)
- [ ] Confirm users with a vessel still get redirected to `boat/new` when appropriate